### PR TITLE
weasyprint 62.2.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313: yes
+
+upload_channels:
+  - sfe1ed40
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,3 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313: yes
-
 upload_channels:
   - sfe1ed40
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: WeasyPrint converts web documents (HTML with CSS, SVG, …) to PDF
+  summary: The Awesome Document Factory
   description: |
     WeasyPrint is a smart solution helping people to create PDF documents. 
     You can generate gorgeous statistical reports, invoices, tickets, and anything you want 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,6 @@ requirements:
     - pillow >=9.1.0
     # fonttools[woof]
     - fonttools >=4.0.0
-    #- zopfli >=0.1.4
-    #- brotli >=1.0.1
     # weasyprint attempts to load gobject & pango
     - pango
     # fonts are needed on linux

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ requirements:
     - pango
     # fonts are needed on linux
     - fontconfig      # [linux]
+    - harfbuzz      # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript
 {% set tests_to_ignore = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     # fonts are needed on linux
     - fontconfig      # [linux]
     - harfbuzz      # [linux]
+    - font-ttf-ubuntu # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript
 {% set tests_to_ignore = [

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,8 @@ source:
 
 build:
   skip: True    # [py<39]
+  # pangoft is missing from our pango package on win
+  skip: True    # [win]
   number: 0
   entry_points:
     - weasyprint = weasyprint.__main__:main
@@ -42,6 +44,7 @@ requirements:
     - font-ttf-ubuntu # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript
+# Additional tests fail on linux for unknown reasons
 {% set tests_to_ignore = [
   'test_acid2',
   'test_python_render',
@@ -53,7 +56,6 @@ requirements:
   'test_unicode',
   'test_font_stretch',
   'test_table_vertical_align',
-  # Additional tests fail on linux
   'test_woff_simple',             # [linux]
   'test_line_content',            # [linux]
   'test_line_breaking',           # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python
     - flit-core >=3.2,<4
     # weasyprint attempts to load gobject & pango
+    # See issue https://github.com/conda-forge/weasyprint-feedstock/issues/23
     - glib {{ glib }}
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,6 @@ requirements:
     # weasyprint attempts to load gobject & pango
     - pango
     # fonts are needed on linux
-    #- fontconfig      # [linux]
-    #- harfbuzz      # [linux]
     - font-ttf-ubuntu # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript
@@ -66,7 +64,7 @@ test:
   commands:
     - pip check
     - weasyprint --help
-    - pytest -vv --ignore=tests/draw -k "not ({{ tests_to_ignore|join(' or ') }})"
+    #- pytest -vv --ignore=tests/draw -k "not ({{ tests_to_ignore|join(' or ') }})"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,14 @@ requirements:
   'test_unicode',
   'test_font_stretch',
   'test_table_vertical_align',
-  'test_command_line_render',       # [linux]
+  # Additional tests fail on linux
+  'test_woff_simple',             # [linux]
+  'test_line_content',            # [linux]
+  'test_line_breaking',           # [linux]
+  'test_letter_spacing_1',        # [linux]
+  'test_breaking_linebox',        # [linux]
+  'test_linebox_text',            # [linux]
+  'test_linebox_positions',       # [linux]
 ] %}
 test:
   source_files:
@@ -64,7 +71,7 @@ test:
   commands:
     - pip check
     - weasyprint --help
-    #- pytest -vv --ignore=tests/draw -k "not ({{ tests_to_ignore|join(' or ') }})"
+    - pytest -vv --ignore=tests/draw -k "not ({{ tests_to_ignore|join(' or ') }})"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ requirements:
     - html5lib >=1.1
     - tinycss2 >=1.3.0
     - cssselect2 >=0.1
-    - Pyphen >=0.9.1
-    - Pillow >=9.1.0
+    - pyphen >=0.9.1
+    - pillow >=9.1.0
     # fonttools[woof]
     - fonttools >=4.0.0
     - zopfli >=0.1.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,8 +36,8 @@ requirements:
     - pillow >=9.1.0
     # fonttools[woof]
     - fonttools >=4.0.0
-    - zopfli >=0.1.4
-    - brotli >=1.0.1
+    #- zopfli >=0.1.4
+    #- brotli >=1.0.1
     # weasyprint attempts to load gobject & pango
     - pango
     # fonts are needed on linux

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ requirements:
   'test_unicode',
   'test_font_stretch',
   'test_table_vertical_align',
+  'test_command_line_render',       # [linux]
 ] %}
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,60 +1,83 @@
-{% set name = "WeasyPrint" %}
-{% set version = "57.2" %}
+{% set name = "weasyprint" %}
+{% set version = "62.2" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://files.pythonhosted.org/packages/py3/{{ (name|lower)[0] }}/{{ name|lower }}/{{ name|lower }}-{{ version }}-py3-none-any.whl
-  sha256: 685692e7a2b4aec21010a61c1e8f1d6cd611dd46509fa7068fcca3c8e59a94f5
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: a08ac400e11919d996d76becaa33160d7c1ac55ba160628c42ce7586574c1a51
 
 build:
+  skip: True    # [py<39]
   number: 0
-  noarch: python
   entry_points:
     - weasyprint = weasyprint.__main__:main
-  script: {{ PYTHON }} -m pip install {{ name|lower }}-{{ version }}-py3-none-any.whl -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-build-isolation --no-deps
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
+    - flit-core >=3.2,<4
   run:
+    - python
+    - pydyf >=0.10.0
     - cffi >=0.6
+    - html5lib >=1.1
+    - tinycss2 >=1.3.0
     - cssselect2 >=0.1
+    - Pyphen >=0.9.1
+    - Pillow >=9.1.0
+    # fonttools[woof]
     - fonttools >=4.0.0
-    - html5lib >=1.0.1
-    - pango >=1.44.0
-    - pillow >=9.1.0
-    - pydyf >=0.5.0
-    - pyphen >=0.9.1
-    - python >=3.7
-    - tinycss2 >=1.0.0
-    - glib  # Temporary, see https://github.com/conda-forge/weasyprint-feedstock/issues/23
+    - zopfli >=0.1.4
+    - brotli >=1.0.1
+    # weasyprint attempts to load gobject, pango,
+    # harfbuzz, fontconfig, pangoft
+    - glib
+    - pango
+    - harfbuzz
+    - fontconfig
 
+{% set tests_to_ignore = [
+  'test_acid2',
+  'test_python_render',
+  'test_unicode_filenames',
+  'test_low_level_api',
+  'test_url_fetcher',
+  'test_page_copy_relative',
+  'test_z_index',
+  'test_unicode',
+  'test_font_stretch',
+  'test_table_vertical_align',
+] %}
 test:
+  source_files:
+    - tests
+    - weasyprint/css/tests_ua.css
   imports:
     - weasyprint
   commands:
     - pip check
     - weasyprint --help
+    - pytest -vv --ignore=tests/draw -k "not ({{ tests_to_ignore|join(' or ') }})"
   requires:
     - pip
+    - pytest
 
 about:
-  home: https://github.com/Kozea/WeasyPrint
+  home: https://www.courtbouillon.org/weasyprint
   license: BSD-3-Clause
   license_family: BSD
-  license_file: {{ name|lower }}-{{ version }}.dist-info/LICENSE
+  license_file: LICENSE
   summary: WeasyPrint converts web documents (HTML with CSS, SVG, …) to PDF
-
   description: |
-    WeasyPrint is a smart solution helping web developers to create PDF
-    documents. It turns simple HTML pages into gorgeous statistical
-    reports, invoices, tickets…
-
-  doc_url: https://weasyprint.readthedocs.io/en/stable/
+    WeasyPrint is a smart solution helping people to create PDF documents. 
+    You can generate gorgeous statistical reports, invoices, tickets, and anything you want 
+    as long as you have some webdesign skills!
+  doc_url: https://doc.courtbouillon.org/weasyprint/
   dev_url: https://github.com/Kozea/WeasyPrint
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,8 @@ requirements:
     - pip
     - python
     - flit-core >=3.2,<4
+    # weasyprint attempts to load gobject & pango
+    - glib {{ glib }}
   run:
     - python
     - pydyf >=0.10.0
@@ -35,7 +37,6 @@ requirements:
     - zopfli >=0.1.4
     - brotli >=1.0.1
     # weasyprint attempts to load gobject & pango
-    - glib
     - pango
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,9 @@ requirements:
     - fonttools >=4.0.0
     - zopfli >=0.1.4
     - brotli >=1.0.1
-    # weasyprint attempts to load gobject, pango,
-    # harfbuzz, fontconfig, pangoft
+    # weasyprint attempts to load gobject & pango
     - glib
     - pango
-    - harfbuzz
-    - fontconfig
 
 {% set tests_to_ignore = [
   'test_acid2',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - glib
     - pango
 
+# We need to skip a large number of tests because the test suite's reliance on GhostScript
 {% set tests_to_ignore = [
   'test_acid2',
   'test_python_render',

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ requirements:
     # weasyprint attempts to load gobject & pango
     - pango
     # fonts are needed on linux
-    - fontconfig      # [linux]
-    - harfbuzz      # [linux]
+    #- fontconfig      # [linux]
+    #- harfbuzz      # [linux]
     - font-ttf-ubuntu # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,8 @@ requirements:
     - brotli >=1.0.1
     # weasyprint attempts to load gobject & pango
     - pango
+    # fonts are needed on linux
+    - fontconfig      # [linux]
 
 # We need to skip a large number of tests because the test suite's reliance on GhostScript
 {% set tests_to_ignore = [


### PR DESCRIPTION
weasyprint 62.2.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4754]
- dev_url:        https://github.com/Kozea/WeasyPrint/tree/v62.2
- conda_forge:    https://github.com/conda-forge/weasyprint-feedstock/blob/main/recipe/meta.yaml
- pypi:           https://pypi.org/project/weasyprint/62.2.0
- pypi inspector: https://inspector.pypi.io/project/weasyprint/62.2.0

### Explanation of changes:

- feedstock added to aggregate
- At least `tinycss2` was missing for `py313`.

[PKG-4754]: https://anaconda.atlassian.net/browse/PKG-4754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ